### PR TITLE
restrict passkey authentication for platform only

### DIFF
--- a/src/lib/webauthn-prf/client.ts
+++ b/src/lib/webauthn-prf/client.ts
@@ -158,6 +158,10 @@ export async function register(
     console.debug(credential);
   }
 
+  if (credential.authenticatorAttachment !== 'platform') {
+    throw new Error('Cross Platform authentication is not supported.');
+  }
+
   const response = credential.response as AuthenticatorAttestationResponse;
 
   const publicKey = (
@@ -287,6 +291,10 @@ export async function authenticate(
 
   if (options.debug) {
     console.debug(auth);
+  }
+
+  if (auth.authenticatorAttachment !== 'platform') {
+    throw new Error('Cross Platform authentication is not supported.');
   }
 
   const response = auth.response as AuthenticatorAssertionResponse;


### PR DESCRIPTION
### Issue
Cross-Platform authentication is buggy on ios

### Reproduce

### Root cause

### Fix
Restrict Cross-platform authentication

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests